### PR TITLE
Nathan save schema

### DIFF
--- a/src/Editor/BuilderButtons/BuilderButtons.js
+++ b/src/Editor/BuilderButtons/BuilderButtons.js
@@ -5,20 +5,27 @@ import Context from '../../context';
 import styles from './BuilderButton.style';
 
 const BuilderButtons = () => {
-  const { schema, setSchema } = useContext(Context);
+  const { schema, setSchema, schemataList, setSchemataList } = useContext(Context);
   const isValidSchema = validateSchema(schema);
   const schemaSize = schema.length;
   const useStyles = styles(makeStyles, isValidSchema, schemaSize);
   const classes = useStyles();
   const clearSchemaBuilder = () => setSchema([]);
+  const saveValidSchema = () => {
+    if (isValidSchema) {
+      setSchemataList([...schemataList, schema]); // save
+      setSchema([]); // clear builder
+    } 
+  }
   return (
     <Box mt="1rem" style={{display: 'flex', flexDirection: 'row-reverse'}}>
       <Button 
         classes={ {root: [classes.saveBtn, classes.common].join(' ')} }
         variant="outlined"
         disabled={ !isValidSchema }
+        onClick={ saveValidSchema }
       >
-        Save
+        save
       </Button>
       <Button
         classes={ {root: [classes.clearBtn, classes.common].join(' ')} }
@@ -26,7 +33,7 @@ const BuilderButtons = () => {
         disabled={ schemaSize === 0 }
         onClick={ clearSchemaBuilder }
       >
-        Clear
+        clear
       </Button>
     </Box>
   );

--- a/src/Editor/BuilderButtons/BuilderButtons.js
+++ b/src/Editor/BuilderButtons/BuilderButtons.js
@@ -14,7 +14,7 @@ const BuilderButtons = () => {
   const saveValidSchema = () => {
     if (isValidSchema) {
       setSchemataList([...schemataList, schema]); // save
-      setSchema([]); // clear builder
+      clearSchemaBuilder(); // clear schema builder
     } 
   }
   return (

--- a/src/Editor/DnDElement/dndElementConfig.js
+++ b/src/Editor/DnDElement/dndElementConfig.js
@@ -2,7 +2,7 @@ import grey from '@material-ui/core/colors/grey';
 
 export const getStyles = (color) => {
   return {
-    backgroundColor: color ? color['500'] : grey['700'],
+    backgroundColor: color ? color : grey['700'],
   };
 }
 

--- a/src/Editor/LetterPicker/letterPickerConfig.js
+++ b/src/Editor/LetterPicker/letterPickerConfig.js
@@ -3,7 +3,7 @@ export const getLetters =  (count) => {
   return [...Array(count)].map((el, i) => {
     return {
       value: String.fromCharCode(112 + i), 
-      bgColor: Colors[i],
+      bgColor: Colors[i]['500'],
       elType: 'L',
     }
   });


### PR DESCRIPTION
- Saw that there was no need to pass in the entire Color object as data with the letter cards. Refactored to only pass actual bg color we need to display the component.

- Save button functional - sample schema list data for schemas '_p_' and '_p_ and _q_' :
`[[{"value":"p","bgColor":"#9c27b0","elType":"L"}],[{"value":"p","bgColor":"#9c27b0","elType":"L"},{"value":"∧","elType":"O"},{"value":"q","bgColor":"#e91e63","elType":"L"}]]`